### PR TITLE
change theme to remote

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ instagram_username: mulheres.em.ia
 linkedin_username: mulheres-em-ia
 
 # Build settings
-theme: jekyll-theme-clean-blog
+remote_theme: jekyll-theme-clean-blog
 paginate:           5
 paginate_path:      "/posts/page:num/"
 plugins:


### PR DESCRIPTION
## Objective 

Fixed build error in the theme. The issue was discussed [here](https://stackoverflow.com/questions/70654418/github-pages-build-error-the-jekyll-theme-hydejack-theme-could-not-be-found), and I replaced theme with remote_theme to attempt to resolve the problem

## Type of change
- [X] Bugfix